### PR TITLE
Override build steps for micropython v1.12

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: micropython
-version: "1.11"
+version: "1.12"
 summary: MicroPython Unix port
 description: |
   MicroPython is a lean and efficient Python implementation for microcontrollers and constrained systems.
@@ -10,7 +10,7 @@ grade: stable
 
 apps:
   micropython:
-    command: usr/local/bin/micropython
+    command: bin/micropython
     plugs:
       - home
       - network
@@ -22,7 +22,13 @@ build-packages:
 
 parts:
   micropython:
-    plugin: make
-    source: https://github.com/micropython/micropython/releases/download/v1.11/micropython-1.11.tar.gz
-    source-subdir: ports/unix
+    plugin: nil
+    source: https://github.com/micropython/micropython/releases/download/v1.12/micropython-1.12.tar.gz
     source-type: tar
+    override-build: |
+      cd mpy-cross
+      make
+      cd ../ports/unix
+      make
+      mkdir $SNAPCRAFT_PART_INSTALL/bin
+      cp micropython $SNAPCRAFT_PART_INSTALL/bin


### PR DESCRIPTION
This changeset upgrades Micropython to v1.12. However, due to the changes
in Micropython Makefile, we need to build mpy-cross in a separate step.
The `make` plugin from snapcraft can't handle this case to my best
knowledge so that we have to use custom build steps.