### PR TITLE
Use core18 base

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -4,8 +4,9 @@ summary: MicroPython Unix port
 description: |
   MicroPython is a lean and efficient Python implementation for microcontrollers and constrained systems.
 
-grade: stable
+base: core18
 confinement: strict
+grade: stable
 
 apps:
   micropython:


### PR DESCRIPTION
`core18` is the current standard base for snap building and is based
on Ubuntu 18.04LTS.